### PR TITLE
サイドバーに参加しているグループ名と最新メッセージ表示

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -3,4 +3,16 @@ class Group < ApplicationRecord
   has_many :users, through: :group_users
   has_many :messages
   validates :name, presence: true, uniqueness: true
+
+  def show_last_message
+    if (last_message = messages.last).present?
+      if last_message.content?
+        last_message.content
+      else
+        '画像が投稿されています'
+      end
+    else
+      'まだメッセージはありません。'
+    end
+  end
 end

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -17,6 +17,6 @@
           .bottom-items__group
             = group.name
         .bottom-items__message
-          まだメッセージがありません
+          = group.show_last_message
 
   


### PR DESCRIPTION
# What
サイドバーにログインユーザーの参加しているグループ名と最新メッセージ表示。
最新が画像の場合とまだメッセージがない場合とで表示メッセージが異なる。

# Why
参加しているグループを一覧で表示し、クリック動作のみでグループを切り替えられるのは便利なため。
