### PR TITLE
右上ヘッダーのグループ名と所属ユーザー名を表示

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,7 +1,6 @@
 class GroupsController < ApplicationController
 
   def index
-    
   end
 
   def new
@@ -35,5 +34,6 @@ class GroupsController < ApplicationController
   def group_params
     params.require(:group).permit(:name, user_ids: [])
   end
+  
 
 end

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -1,9 +1,11 @@
 .main-chat
   .main-chat__header
     .main-chat__header--left
-      test
+      = @group.name
       .main-chat__header--left--item
-        Member:masa
+        Member:
+        - @group.users.each do |user|
+          = user.name
     .main-chat__header--right
       %a{href: "#"}
         Edit


### PR DESCRIPTION
# What
ChatSpace右上に、現在選択しているグループ名とそのグループに所属しているユーザー名を表示する。


# Why
選択しているグループ名とユーザー名を表示することで、選択ミスを防ぐため。