### PR TITLE
Edit-btn

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -17,6 +17,13 @@ class MessagesController < ApplicationController
     end
   end
 
+  def edit
+  end
+
+  def update
+  end
+  
+
   private
 
   def message_params

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -7,7 +7,7 @@
         - @group.users.each do |user|
           = user.name
     .main-chat__header--right
-      %a{href: "#"}
+      %a{href: edit_group_path(@group)}
         Edit
 
   .main-chat__message

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,6 @@ Rails.application.routes.draw do
   root "groups#index"
   resources :users, only: [:edit, :update]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
-    resources :messages, only: [:index, :create]
+    resources :messages, only: [:index, :create, :edit, :update]
   end
 end


### PR DESCRIPTION
# What
Editボタンをクリックするとグループ名と所属メンバーを編集する事ができる画面へ遷移し、編集後はトップ画面に戻る。

# Why
グループ作成後、メンバーの入れ替えや使用用途の変更に対応するため。