### PR TITLE
グループ編集後の画面を今いるグループのメッセージ一覧に変更

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -24,7 +24,7 @@ class GroupsController < ApplicationController
   def update
     @group = Group.find(params[:id])
     if @group.update(group_params)
-      redirect_to root_path, notice: 'グループを更新しました'
+      redirect_to group_messages_path(@group), notice: 'グループを更新しました'
     else
       render :edit
     end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -16,12 +16,6 @@ class MessagesController < ApplicationController
       render :index
     end
   end
-
-  def edit
-  end
-
-  def update
-  end
   
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,6 @@ Rails.application.routes.draw do
   root "groups#index"
   resources :users, only: [:edit, :update]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
-    resources :messages, only: [:index, :create, :edit, :update]
+    resources :messages, only: [:index, :create]
   end
 end


### PR DESCRIPTION
# What
グループ編集後、ルートパスにリダイレクトしていたが、今いるグループのメッセージ一覧表示にリダイレクトする。

# Why
毎回ルートパスに戻っていてはユーザーのストレスになるため。